### PR TITLE
Support Compute Module 4

### DIFF
--- a/Lib/Support/Platform.cpp
+++ b/Lib/Support/Platform.cpp
@@ -183,7 +183,7 @@ PlatformInfo::PlatformInfo() {
   }
 
   if (!platform_id.empty() && is_pi_platform) {
-    has_vc4 = (platform_id.npos == platform_id.find("Pi 4"));
+    has_vc4 = (platform_id.npos == platform_id.find("Pi 4") && platform_id.npos == platform_id.find("Pi Compute Module 4"));
   }
 
 #ifndef QPU_MODE

--- a/Lib/Support/basics.h
+++ b/Lib/Support/basics.h
@@ -3,6 +3,7 @@
 #include <vector>
 #include "Exception.h"
 #include "debug.h"
+#include <stdint.h>
 
 namespace V3DLib {
 

--- a/Lib/Target/instr/ALUOp.h
+++ b/Lib/Target/instr/ALUOp.h
@@ -1,6 +1,7 @@
 #ifndef _V3DLIB_TARGET_SYNTAX_INSTR_ALUOP_H_
 #define _V3DLIB_TARGET_SYNTAX_INSTR_ALUOP_H_
 #include <string>
+#include <stdint.h>
 
 namespace V3DLib {
 

--- a/Lib/Target/instr/Conditions.h
+++ b/Lib/Target/instr/Conditions.h
@@ -1,6 +1,7 @@
 #ifndef _V3DLIB_TARGET_SYNTAX_INSTR_CONDITIONS_H_
 #define _V3DLIB_TARGET_SYNTAX_INSTR_CONDITIONS_H_
 #include <string>
+#include <stdint.h>
 
 namespace V3DLib {
 

--- a/Lib/Target/instr/Imm.h
+++ b/Lib/Target/instr/Imm.h
@@ -1,6 +1,7 @@
 #ifndef _V3DLIB_TARGET_INSTR_IMM_H_
 #define _V3DLIB_TARGET_INSTR_IMM_H_
 #include <string>
+#include <stdint.h>
 
 namespace V3DLib {
 

--- a/Lib/v3d/KernelDriver.cpp
+++ b/Lib/v3d/KernelDriver.cpp
@@ -732,7 +732,9 @@ bool checkUniformAtTop(V3DLib::Instr::List const &instrs) {
  * Translate instructions from target to v3d
  */
 void _encode(V3DLib::Instr::List const &instrs, Instructions &instructions) {
+#ifdef DEBUG
   assertq(checkUniformAtTop(instrs), "_encode(): checkUniformAtTop() failed (v3d)", true);
+#endif
   bool prev_was_init_begin = false;
   bool prev_was_init_end    = false;
 


### PR DESCRIPTION
This small PR implements support for Raspberry Pi Compute Module 4. It achieves this by detecting v3d if platform is `Pi Compute Module 4`.
Also fixes release build.